### PR TITLE
power: Enable 4+0 core config for display off cases

### DIFF
--- a/power/power-8992.c
+++ b/power/power-8992.c
@@ -115,7 +115,6 @@ int power_hint_override(struct power_module *module, power_hint_t hint, void *da
 
 int set_interactive_override(struct power_module *module, int on)
 {
-    return HINT_HANDLED; /* Don't excecute this code path, not in use */
     char governor[80];
 
     if (get_scaling_governor(governor, sizeof(governor)) == -1) {
@@ -128,7 +127,7 @@ int set_interactive_override(struct power_module *module, int on)
         /* Display off */
         if ((strncmp(governor, INTERACTIVE_GOVERNOR, strlen(INTERACTIVE_GOVERNOR)) == 0) &&
             (strlen(governor) == strlen(INTERACTIVE_GOVERNOR))) {
-            int resource_values[] = {}; /* dummy node */
+            int resource_values[] = {0x777}; /* 4+0 core config in display off */
             if (!display_hint_sent) {
                 perform_hint_action(DISPLAY_STATE_HINT_ID,
                 resource_values, sizeof(resource_values)/sizeof(resource_values[0]));

--- a/power/power-8994.c
+++ b/power/power-8994.c
@@ -193,7 +193,6 @@ int power_hint_override(__attribute__((unused)) struct power_module *module,
 
 int set_interactive_override(__attribute__((unused)) struct power_module *module, int on)
 {
-    return HINT_HANDLED; /* Don't excecute this code path, not in use */
     char governor[80];
 
     if (get_scaling_governor(governor, sizeof(governor)) == -1) {
@@ -206,7 +205,7 @@ int set_interactive_override(__attribute__((unused)) struct power_module *module
         /* Display off */
         if ((strncmp(governor, INTERACTIVE_GOVERNOR, strlen(INTERACTIVE_GOVERNOR)) == 0) &&
             (strlen(governor) == strlen(INTERACTIVE_GOVERNOR))) {
-            int resource_values[] = {}; /* dummy node */
+            int resource_values[] = {0x777}; /* 4+0 core config in display off */
             if (!display_hint_sent) {
                 perform_hint_action(DISPLAY_STATE_HINT_ID,
                 resource_values, sizeof(resource_values)/sizeof(resource_values[0]));


### PR DESCRIPTION
This change enables 4+0 core config for display off
sceanrios and in display off scenario system should
go back to default core config.

Change-Id: I57795988e7e0f1b2c1e160e2e454549a14bbde50
